### PR TITLE
Document usage of this repository

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,0 +1,17 @@
+# Ignore any locally installed files to make builds reproducible
+#
+# (? is an deliberately chosen, invalid path. Unsetting the environment
+# variable or setting it to the empty string would have LaTeX search the
+# default texmf directory location, which we can only avoid by using an
+# invalid path)
+$ENV{"TEXMFHOME"} = "?";
+
+# Reset all search paths
+$ENV{"BIBINPUTS"} = "";
+$ENV{"BSTINPUTS"} = "";
+$ENV{"TEXINPUTS"} = "";
+
+# Only search within the supplied includes directory
+ensure_path("BIBINPUTS", "./includes//");
+ensure_path("BSTINPUTS", "./includes//");
+ensure_path("TEXINPUTS", "./includes//");

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -7,11 +7,6 @@
 $ENV{"TEXMFHOME"} = "?";
 
 # Reset all search paths
-$ENV{"BIBINPUTS"} = "";
-$ENV{"BSTINPUTS"} = "";
-$ENV{"TEXINPUTS"} = "";
-
-# Only search within the supplied includes directory
-ensure_path("BIBINPUTS", "./includes//");
-ensure_path("BSTINPUTS", "./includes//");
-ensure_path("TEXINPUTS", "./includes//");
+$ENV{"BIBINPUTS"} = "./include//:";
+$ENV{"BSTINPUTS"} = "./include//:";
+$ENV{"TEXINPUTS"} = "./include//:";

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -1,6 +1,6 @@
 # Ignore any locally installed files to make builds reproducible
 #
-# (? is an deliberately chosen, invalid path. Unsetting the environment
+# (? is a deliberately chosen, invalid path. Unsetting the environment
 # variable or setting it to the empty string would have LaTeX search the
 # default texmf directory location, which we can only avoid by using an
 # invalid path)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ## Usage
 
 The bibliography is meant to be used as a **Git submodule** within your paper repository.
-Conceptually, this means that Git will maintain a copy of the bibliography within a subdirectory of your own repository (we suggest `includes/bibliography`).
+Conceptually, this means that Git will maintain a copy of the bibliography within a subdirectory of your own repository (we suggest `include/bibliography`).
 
 Git submodules are always **locked to a specific commit.**
 In other words, the bibliography **won’t automatically update itself,** even when pulling in the latest changes of your paper repository.
 You’ll have to **manually update the bibliography** whenever necessary.
 
-On another note, **never edit the content of the submodule directly,** that is, within `includes/bibliography`.
+On another note, **never edit the content of the submodule directly,** that is, within `include/bibliography`.
 If you need new entries added, clone the bibliography to a location outside of your paper repository and contribute from there.
 
 Read more about Git submodules on the [GitHub Blog][github-blog-git-submodules] and the in [Pro Git book][pro-git-book-git-submodules].
@@ -20,7 +20,7 @@ Read more about Git submodules on the [GitHub Blog][github-blog-git-submodules] 
 
 **Add the bibliography as a submodule** to your paper repository as follows:
 ```sh
-$ git submodule add ../bibliography includes/bibliography
+$ git submodule add ../bibliography include/bibliography
 ```
 (Replace `../bibliography` with `https://github.com/krr-up/bibliography` if your repository is hosted outside of the [`krr-up` organization][krr-up].)
 
@@ -34,7 +34,7 @@ The bibliography will now stay at the latest state of the `master` branch **at t
 
 ### Using the Bibliography with LaTeX
 
-By default, the LaTeX toolchain won’t attempt to look for the bibliography within `includes/bibliography`.
+By default, the LaTeX toolchain won’t attempt to look for the bibliography within `include/bibliography`.
 If you build your paper with [`latexmk`][latexmk] (we can only recommend that), this can be easily solved.
 Simply copy the [`.latexmkrc`][.latexmkrc] file to the top level of your repository, and LaTeX will automatically find the bibliography if you just run `latexmk`:
 ```sh
@@ -53,11 +53,11 @@ export TEXINPUTS="./include//:"
 You can **bring the latest bibliography updates to your paper repository** as follows:
 
 ```sh
-$ cd includes/bibliography
+$ cd include/bibliography
 $ git fetch
 $ git reset --hard origin/master
 $ cd ../..
-$ git add includes/bibliography
+$ git add include/bibliography
 $ git commit -m "Update bibliography"
 $ git push
 ```
@@ -69,8 +69,8 @@ $ git submodule update --init --recursive
 **every time one of the following happens:**
 - You **clone** your paper repository from scratch.
 - Someone else **updates the bibliography** to a newer version.
-- Files in `includes/bibliography` are **missing** or LaTeX complains about them.
-- `git status` tells you `modified: includes/bibliography (new commits)` and you didn’t expect this.
+- Files in `include/bibliography` are **missing** or LaTeX complains about them.
+- `git status` tells you `modified: include/bibliography (new commits)` and you didn’t expect this.
 - Someone else adds a **new submodule** to your paper repository.
 
 ## Contributing New BibTeX Entries

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ $ git submodule update --init --recursive
 
 ## Contributing New BibTeX Entries
 
-Before creating new BibTeX entries, **check whether they are already contained** in [lit.bib], [procs.bib], or [akku.bib].
-If not, add the new entries to [lit.bib] and **open a pull request.**
+Before creating new BibTeX entries, **check whether they are already contained** in [`krr.bib`][krr.bib] or [`procs.bib`][procs.bib].
+If not, add the new entries accordingly and **open a pull request.**
 Please make sure that new BibTeX entries are **in line with the [guidelines](#guidelines-for-new-bibtex-entries)** below.
 We will then review and merge your pull request in a timely fashion.
 
@@ -158,7 +158,7 @@ Don’t abbreviate **journal names.**
 
 > example: `ACM Transactions on Computational Logic` but not `ACM Trans. on Comp. Log.`
 
-Use the **strings** defined in [lit.bib] for journal names.
+Use the **strings** defined in [`krr.bib`][krr.bib] for journal names.
 
 > example: `@STRING{lncs    = "Lecture Notes in Computer Science" }` for use in BibTex entries as `series =	 lncs`
 
@@ -174,8 +174,7 @@ The bibliography style and BibTeX will sort it out uniformly.
 
 Generally speaking, **never copy/paste** the contents of fields from PDF files because this might lead to issues with special characters (for instance, the ligature `ﬁ` might not be rendered at all by LaTeX and BibTeX).
 
-[akku.bib]: akku.bib
-[lit.bib]: lit.bib
+[krr.bib]: krr.bib
 [procs.bib]: procs.bib
 [.latexmkrc]: .latexmkrc
 [krr-up]: https://github.com/krr-up

--- a/README.md
+++ b/README.md
@@ -2,33 +2,69 @@
 
 > BibTeX bibliography files of all papers referenced by the group
 
-## Installation
+## Usage
 
-These instructions will make all BibTeX files in this repository available to BibTeX on your machine.
+The bibliography is meant to be used as a **Git submodule** within your paper repository.
+Conceptually, this means that Git will maintain a copy of the bibliography within a subdirectory of your own repository (we suggest `includes/bibliography`).
 
-The following commands will first locate or create the directory where your TeX installation expects BibTeX files.
-This repository will then be cloned to that location.
+Git submodules are always **locked to a specific commit.**
+In other words, the bibliography **won’t automatically update itself,** even when pulling in the latest changes of your paper repository.
+You’ll have to **manually update the bibliography** whenever necessary.
+
+On another note, **never edit the content of the submodule directly,** that is, within `includes/bibliography`.
+If you need new entries added, clone the bibliography to a location outside of your paper repository and contribute from there.
+
+Read more about Git submodules on the [GitHub Blog][github-blog-git-submodules] and the in [Pro Git book][pro-git-book-git-submodules].
+
+### Adding the Bibliography to your Paper Repository
+
+**Add the bibliography as a submodule** to your paper repository as follows:
+```sh
+$ git submodule add ../bibliography includes/bibliography
+```
+(Replace `../bibliography` with `https://github.com/krr-up/bibliography` if your repository is hosted outside of the [`krr-up` organization][krr-up].)
+
+Next, **commit and push** the changes to make the submodule available to your coworkers.
+After your coworkers have pulled the change, they will need to **execute the following command:**
+```sh
+$ git submodule update --init --recursive
+```
+
+The bibliography will now stay at the latest state of the `master` branch **at the time of adding the submodule** unless manually updated later on.
+
+### Using the Bibliography with LaTeX
+
+By default, the LaTeX toolchain won’t attempt to look for the bibliography within `includes/bibliography`.
+If you build your paper with [`latexmk`][latexmk] (we can only recommend that), this can be easily solved.
+Simply copy the [`.latexmkrc`][.latexmkrc] file to the top level of your repository, and LaTeX will automatically find the bibliography if you just run `latexmk`:
+```sh
+$ latexmk -pdf paper.tex
+```
+
+### Updating the Bibliography in your Paper Repository
+
+You can **bring the latest bibliography updates to your paper repository** as follows:
 
 ```sh
-$ mkdir -p $(kpsewhich -var-value=TEXMFHOME)/bibtex/bib
-$ cd "$_"
-$ git clone https://github.com/krr-up/bibliography.git
+$ cd includes/bibliography
+$ git fetch
+$ git reset --hard origin/master
+$ cd ../..
+$ git add includes/bibliography
+$ git commit -m "Update bibliography"
+$ git push
 ```
 
-If you prefer, you can clone the repository to another location and then create a symbolic link to the path TeX expects.
-
+Finally, keep in mind that you need to run
 ```sh
-$ cd <preferred location>
-$ git clone https://github.com/krr-up/bibliography.git
-$ mkdir -p $(kpsewhich -var-value=TEXMFHOME)/bibtex/bib
-$ ln -s <preferred location>/bibliography "$_"
+$ git submodule update --init --recursive
 ```
-
-Now, you can use the bibliography in your LaTeX file:
-
-```latex
-\bibliography{lit,procs}
-```
+**every time one of the following happens:**
+- You **clone** your paper repository from scratch.
+- Someone else **updates the bibliography** to a newer version.
+- Files in `includes/bibliography` are **missing** or LaTeX complains about them.
+- `git status` tells you `modified: includes/bibliography (new commits)` and you didn’t expect this.
+- Someone else adds a **new submodule** to your paper repository.
 
 ## Contributing New BibTeX Entries
 
@@ -128,3 +164,8 @@ Generally speaking, **never copy/paste** the contents of fields from PDF files b
 [akku.bib]: akku.bib
 [lit.bib]: lit.bib
 [procs.bib]: procs.bib
+[.latexmkrc]: .latexmkrc
+[krr-up]: https://github.com/krr-up
+[latexmk]: https://mg.readthedocs.io/latexmk.html
+[github-blog-git-submodules]: https://github.blog/2016-02-01-working-with-submodules/
+[pro-git-book-git-submodules]: https://git-scm.com/book/en/v2/Git-Tools-Submodules

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Simply copy the [`.latexmkrc`][.latexmkrc] file to the top level of your reposit
 $ latexmk -pdf paper.tex
 ```
 
+If you do not use `latexmk`, you need to set the following environment variables in your `.bashrc` or LaTeX IDE instead:
+```sh
+export BIBINPUTS="./include//:"
+export BSTINPUTS="./include//:"
+export TEXINPUTS="./include//:"
+```
+
 ### Updating the Bibliography in your Paper Repository
 
 You can **bring the latest bibliography updates to your paper repository** as follows:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ export BSTINPUTS="./include//:"
 export TEXINPUTS="./include//:"
 ```
 
+Now, you can use the bibliography in your LaTeX file:
+
+```sh
+\bibliography{krr,procs}
+```
+
 ### Updating the Bibliography in your Paper Repository
 
 You can **bring the latest bibliography updates to your paper repository** as follows:


### PR DESCRIPTION
This adds a new section on using this repository as a Git submodule within paper repositories.

@rkaminsk: I now recall why I reset the paths in `.latexmkrc`. The reason is that I like to build LaTeX documents in a way that is 100 % reproducible. Having include paths for bibliography, LaTeX styles/classes, etc. configured per system is in opposition to this goal. For this reason, I decided to reset these include paths in `.latexmkrc`. This avoids situations where 1) someone is missing a style class or similar that coworkers just assume to be present on your machine or 2) someone else has an outdated version of a dependency and results look different (I’m talking about the LLNCS vs. `svproc` mess in particular).

## To Do

- [x] Add a section on setting environment variables globally instead of using `.latexmkrc` (@rkaminsk: Can you send me your configuration?)
- [x] Work around `ensure_path` on systems where the directive isn’t present

Fixes #1.