### PR TITLE
Add references for YURIFEST 2020 anthem paper

### DIFF
--- a/krr.bib
+++ b/krr.bib
@@ -7072,6 +7072,13 @@
   crossref =	 "lpnmr09"
 }
 
+@InProceedings{erdlif01a,
+  author =	 "E. Erdem and V. Lifschitz",
+  title =	 "Fages' Theorem for Programs with Nested Expressions",
+  crossref =	 "iclp01",
+  pages =	 "242-254"
+}
+
 @Article{erdlif03a,
   author =	 "E. Erdem and V. Lifschitz",
   title =	 "Tight Logic Programs",
@@ -12908,6 +12915,16 @@
   pages =	 "7-12"
 }
 
+@Article{lifschitz17a,
+  author =	 "V. Lifschitz",
+  title =	 "Achievements in Answer Set Programming",
+  journal =	 tplp,
+  year =	 2017,
+  volume =	 17,
+  number =	 "5-6",
+  pages =	 "961-973"
+}
+
 @Book{lifschitz19a,
   author =	 "V. Lifschitz",
   title =	 "Answer Set Programming",
@@ -13552,6 +13569,16 @@
   title =	 "{LTL}$_f$ Satisfiability Checking",
   pages =	 "513-518",
   crossref =	 "ecai14"
+}
+
+@Article{llotop84a,
+  author =	 "J. Lloyd and R. Topor",
+  title =	 "Making {P}rolog more Expressive",
+  journal =	 jlp,
+  year =	 1984,
+  volume =	 1,
+  number =	 3,
+  pages =	 "225-240"
 }
 
 @Book{lloyd87,
@@ -16423,6 +16450,13 @@
   booktitle =	 ijcai,
   year =	 1989,
   pages =	 "1206-1212"
+}
+
+@InProceedings{regvor19a,
+  author =	 "G. Reger and A. Voronkov",
+  title =	 "Induction in Saturation-Based Proof Search",
+  crossref =	 "cade19",
+  pages =	 "477-494"
 }
 
 @InProceedings{reicri81,

--- a/procs.bib
+++ b/procs.bib
@@ -520,6 +520,16 @@
   publisher =	 springer
 }
 
+@Proceedings{cade19,
+  title =	 "Proceedings of the Twenty-seventh International Conference on Automated Deduction (CADE'19)",
+  year =	 2019,
+  booktitle =	 "Proceedings of the Twenty-seventh International Conference on Automated Deduction (CADE'19)",
+  editor =	 "P. Fontaine",
+  volume =	 11716,
+  series =	 lncs,
+  publisher =	 springer
+}
+
 @Proceedings{cade90,
   title =	 "Proceedings of the Tenth International Conference on Automated Deduction (CADE'90)",
   year =	 1990,
@@ -1515,6 +1525,16 @@
   editor =	 "M. Leuschel and T. Schrijvers",
   volume =	 "14(4-5)",
   series =	 "Theory and Practice of Logic Programming, Online Supplement"
+}
+
+@Proceedings{iclp01,
+  title =	 "Proceedings of the Seventeenth International Conference on Logic Programming (ICLP'01)",
+  year =	 2001,
+  booktitle =	 "Proceedings of the Seventeenth International Conference on Logic Programming (ICLP'01)",
+  editor =	 "P. Codognet",
+  volume =	 2237,
+  series =	 lncs,
+  publisher =	 springer
 }
 
 @Proceedings{iclp02,


### PR DESCRIPTION
This adds the missing references used in the anthem paper submitted to YURIFEST 2020.