### PR TITLE
Modify duplicate key

### DIFF
--- a/krr.bib
+++ b/krr.bib
@@ -405,13 +405,6 @@
   year = {2019}
 }
 
-@inproceedings{agcafapepevi22b,
-  title = {Syntactic {ASP} Forgetting with Forks},
-  author = {F. Aguado and P. Cabalar and J. Fandinno and D. Pearce and G. P{\'e}rez and C. Vidal},
-  crossref = {lpnmr22},
-  pages = {3-15}
-}
-
 @article{agcafapepevi22a,
   title = {A polynomial reduction of forks into logic programs},
   author = {F. Aguado and P. Cabalar and J. Fandinno and D. Pearce and G. P{\'e}rez and C. Vidal},
@@ -419,6 +412,13 @@
   pages = {103712},
   volume = {308},
   year = {2022}
+}
+
+@inproceedings{agcafapepevi22b,
+  title = {Syntactic {ASP} Forgetting with Forks},
+  author = {F. Aguado and P. Cabalar and J. Fandinno and D. Pearce and G. P{\'e}rez and C. Vidal},
+  crossref = {lpnmr22},
+  pages = {3-15}
 }
 
 @inproceedings{agcafapevi20a,

--- a/krr.bib
+++ b/krr.bib
@@ -405,7 +405,7 @@
   year = {2019}
 }
 
-@inproceedings{agcafapepevi22a,
+@inproceedings{agcafapepevi22b,
   title = {Syntactic {ASP} Forgetting with Forks},
   author = {F. Aguado and P. Cabalar and J. Fandinno and D. Pearce and G. P{\'e}rez and C. Vidal},
   crossref = {lpnmr22},


### PR DESCRIPTION
Changed "Syntactic {ASP} Forgetting with Forks" key to agcafapepevi22b from agcafapepevi22a, as that key was already taken by "A polynomial reduction of forks into logic programs"