### PR TITLE
Move all @book entries to krr.bib.

### DIFF
--- a/krr.bib
+++ b/krr.bib
@@ -355,6 +355,16 @@
   year = {1975}
 }
 
+@book{ads07,
+  title = {Data Streams --- Models and Algorithms},
+  editor = {C. Aggarwal},
+  booktitle = {Data Streams --- Models and Algorithms},
+  publisher = springer,
+  series = {Advances in Database Systems},
+  volume = {31},
+  year = {2007}
+}
+
 @article{agascapevi17a,
   title = {Verification for {ASP} denotational semantics: {A} case study using the {PVS} theorem prover},
   author = {F. Aguado and P. Ascariz and P. Cabalar and G. P{\'e}rez and C. Vidal},
@@ -1158,6 +1168,14 @@
   series = lncs,
   volume = {2942},
   year = {2004}
+}
+
+@book{ARHandbook,
+  title = {Handbook of Automated Reasoning},
+  editor = {A. Robinson and A. Voronkov},
+  booktitle = {Handbook of Automated Reasoning},
+  publisher = {Elsevier and MIT Press},
+  year = {2001}
 }
 
 @article{ariarv98a,
@@ -6203,6 +6221,16 @@ and M. Maratea and F. Ricca and T. Schaub},
   pages = {156-163}
 }
 
+@book{ci04,
+  title = {Special Issue on Preferences in Artificial Intelligence},
+  editor = {J. Delgrande and J. Doyle and U. Junker and F. Rossi and T. Schaub},
+  booktitle = {Special Issue on Preferences in Artificial Intelligence},
+  publisher = wiley,
+  series = {Computational Intelligence},
+  volume = {20(2)},
+  year = {2004}
+}
+
 @article{cimrov00a,
   title = {Conformant Planning via Symbolic Model Checking},
   author = {A. Cimatti and M. Roveri},
@@ -6493,6 +6521,14 @@ and M. Maratea and F. Ricca and T. Schaub},
   pages = {799-814},
   volume = {20},
   year = {2020}
+}
+
+@book{CPHandbook,
+  title = {Handbook of Constraint Programming},
+  editor = {F. Rossi and P. {van Beek} and T. Walsh},
+  booktitle = {Handbook of Constraint Programming},
+  publisher = elsevier,
+  year = {2006}
 }
 
 @article{craaut96a,
@@ -6822,6 +6858,13 @@ and M. Maratea and F. Ricca and T. Schaub},
   author = {R. Dechter},
   publisher = m-k,
   year = {2003}
+}
+
+@book{DeclarativeLP,
+  title = {Declarative Logic Programming: Theory, Systems, and Applications},
+  editor = {M. Kifer and Y. Liu},
+  publisher = {{ACM} / Morgan {\&} Claypool},
+  year = {2018}
 }
 
 @inproceedings{deeireri15a,
@@ -7638,6 +7681,14 @@ and M. Maratea and F. Ricca and T. Schaub},
   author = {J{\"u}rgen Dix},
   crossref = {kr92},
   pages = {591-602}
+}
+
+@book{DLHandbook,
+  title = {The Description Logic Handbook: Theory, Implementation, and Applications},
+  editor = {F. Baader and D. Calvanese and D. McGuinness and D. Nardi and P. Patel-Schneider},
+  booktitle = {The Description Logic Handbook: Theory, Implementation, and Applications},
+  publisher = {Cambridge University Press},
+  year = {2003}
 }
 
 @article{dlv03a,
@@ -8611,6 +8662,14 @@ and M. Maratea and F. Ricca and T. Schaub},
   series = {{EPTCS}},
   volume = {243},
   year = {2017}
+}
+
+@book{EncyclopediaDB,
+  title = {Encyclopedia of Database Systems},
+  editor = {L. Liu and M. {\"O}zsu},
+  booktitle = {Encyclopedia of Database Systems},
+  publisher = springer,
+  year = {2009}
 }
 
 @book{enderton72,
@@ -9605,6 +9664,14 @@ and M. Maratea and F. Ricca and T. Schaub},
   url = {https://dl.acm.org/doi/10.5555/1622572.1622580},
   volume = {27},
   year = {2006}
+}
+
+@book{fpm14,
+  title = {Frequent Pattern Mining},
+  editor = {C. Aggarwal and J. Han},
+  booktitle = {Frequent Pattern Mining},
+  publisher = springer,
+  year = {2014}
 }
 
 @phdthesis{freeman95a,
@@ -13864,6 +13931,14 @@ Benchmarks},
   year = {2019}
 }
 
+@book{jm64,
+  title = {Artificial Intelligence and Mathematical Theory of Computation: Papers in Honor of {J}ohn {M}c{C}arthy},
+  editor = {V. Lifschitz},
+  booktitle = {Artificial Intelligence and Mathematical Theory of Computation: Papers in Honor of {J}ohn {M}c{C}arthy},
+  publisher = {Academic Press},
+  year = {1991}
+}
+
 @book{johnson-laird83,
   title = {Mental Models --- Towards a Cognitive Science of Language, Inference, and Consciousness},
   author = {P. Johnson-Laird},
@@ -14348,6 +14423,14 @@ Benchmarks},
   pages = {953-989},
   volume = {30},
   year = {2020}
+}
+
+@book{kbc14,
+  title = {Knowledge-Based Configuration: From Research to Business Cases},
+  editor = {A. Felfernig and L. Hotz and C. Bagley and J. Tiihonen},
+  booktitle = {Knowledge-Based Configuration: From Research to Business Cases},
+  publisher = {Elsevier/Morgan Kaufmann},
+  year = {2014}
 }
 
 @book{keene89,
@@ -14869,6 +14952,14 @@ Benchmarks},
   year = {1988}
 }
 
+@book{KRHandbook,
+  title = {Handbook of Knowledge Representation},
+  editor = {V. Lifschitz and F. {van Harmelen} and B. Porter},
+  booktitle = {Handbook of Knowledge Representation},
+  publisher = elsevier,
+  year = {2008}
+}
+
 @article{krhuabfifimascsty09a,
   title = {The new Dutch timetable: The {OR} revolution},
   author = {L. Kroon and D. Huisman and E. Abbink and P. Fioole and M. Fischetti and G. Mar{\'o}ti and A. Schrijver and A. Steenbeek and R. Ybema},
@@ -15098,6 +15189,15 @@ Benchmarks},
   pages = {95-101},
   volume = {31},
   year = {1989}
+}
+
+@book{lbai,
+  title = {Logic-Based Artificial Intelligence},
+  editor = {J. Minker},
+  address = {Dordrecht},
+  booktitle = {Logic-Based Artificial Intelligence},
+  publisher = kluwer,
+  year = {2000}
 }
 
 @inproceedings{lealmi09a,
@@ -17620,6 +17720,14 @@ J. Hoffmann and F. Rittinger and C. Anderson and D. Weld and D. Smith and M. Fox
   pages = {218-227}
 }
 
+@book{MLHandbook,
+  title = {Handbook of Modal Logic},
+  editor = {P. Blackburn and F. Wolter and J. van Benthem},
+  booktitle = {Handbook of Modal Logic},
+  publisher = elsevier,
+  year = {2006}
+}
+
 @article{moheliplma13a,
   title = {Iterative and core-guided MaxSAT solving: {A} survey and assessment},
   author = {A. Morgado and F. Heras and M. Liffiton and J. Planes and J. Marques-Silva},
@@ -19138,6 +19246,14 @@ J. Hoffmann and F. Rittinger and C. Anderson and D. Weld and D. Smith and M. Fox
   author = {T. Pham and M. Ali and A. Mileo},
   crossref = {lpnmr19},
   year = {2019}
+}
+
+@book{PHandbook,
+  title = {Handbook of Philosophical Logic},
+  editor = {D. Gabbay and F. Guenthner},
+  booktitle = {Handbook of Philosophical Logic},
+  publisher = springer,
+  year = {2001}
 }
 
 @article{phthsa08a,
@@ -20807,6 +20923,16 @@ J. Hoffmann and F. Rittinger and C. Anderson and D. Weld and D. Smith and M. Fox
   pages = {11-22},
   volume = {7},
   year = {1991}
+}
+
+@book{SATHandbook,
+  title = {Handbook of Satisfiability},
+  editor = {A. Biere and M. Heule and H. {van Maaren} and T. Walsh},
+  booktitle = {Handbook of Satisfiability},
+  publisher = {IOS Press},
+  series = {Frontiers in Artificial Intelligence and Applications},
+  volume = {185},
+  year = {2009}
 }
 
 @inproceedings{satoh88a,
@@ -22697,6 +22823,14 @@ and L. Cohen and T. Kumar and R. Bart{\'a}k and E. Boyarski},
   crossref = {pos13}
 }
 
+@book{TableauHandbook,
+  title = {Handbook of Tableau Methods},
+  editor = {M. {D'Agostino} and D. Gabbay and R. H{\"a}hnle and J. Posegga},
+  booktitle = {Handbook of Tableau Methods},
+  publisher = kluwer,
+  year = {1999}
+}
+
 @inproceedings{tacezdchst03a,
   title = {Load Shedding in a Data Stream Manager},
   author = {N. Tatbul and U. \c{C}etintemel and S. Zdonik and M. Cherniack and M. Stonebraker},
@@ -23038,6 +23172,16 @@ and L. Cohen and T. Kumar and R. Bart{\'a}k and E. Boyarski},
   pages = {99-131},
   volume = {26},
   year = {2013}
+}
+
+@book{TIMEHandbook,
+  title = {Handbook of Temporal Reasoning in Artificial Intelligence},
+  editor = {M. Fisher and D. Gabbay and L. Vila},
+  booktitle = {Handbook of Temporal Reasoning in Artificial Intelligence},
+  publisher = elsevier,
+  series = {Foundations of Artificial Intelligence},
+  volume = {1},
+  year = {2005}
 }
 
 @inproceedings{tisonisu03a,

--- a/procs.bib
+++ b/procs.bib
@@ -283,16 +283,6 @@
   year = {2007}
 }
 
-@book{ads07,
-  title = {Data Streams --- Models and Algorithms},
-  editor = {C. Aggarwal},
-  booktitle = {Data Streams --- Models and Algorithms},
-  publisher = springer,
-  series = {Advances in Database Systems},
-  volume = {31},
-  year = {2007}
-}
-
 @proceedings{agp03,
   title = {Proceedings of the Joint Conference on Declarative Programming (AGP'03)},
   editor = {F. Buccafurri},
@@ -377,14 +367,6 @@
   publisher = springer,
   series = lncs,
   volume = {1957},
-  year = {2001}
-}
-
-@book{ARHandbook,
-  title = {Handbook of Automated Reasoning},
-  editor = {A. Robinson and A. Voronkov},
-  booktitle = {Handbook of Automated Reasoning},
-  publisher = {Elsevier and MIT Press},
   year = {2001}
 }
 
@@ -728,16 +710,6 @@
   year = {2005}
 }
 
-@book{ci04,
-  title = {Special Issue on Preferences in Artificial Intelligence},
-  editor = {J. Delgrande and J. Doyle and U. Junker and F. Rossi and T. Schaub},
-  booktitle = {Special Issue on Preferences in Artificial Intelligence},
-  publisher = wiley,
-  series = {Computational Intelligence},
-  volume = {20(2)},
-  year = {2004}
-}
-
 @proceedings{cikm06,
   title = {Proceedings of the Fifteenth International Conference on Information and Knowledge Management},
   editor = {P. Yu and V. Tsotras and E. Fox and B. Liu},
@@ -1072,14 +1044,6 @@
   year = {2015}
 }
 
-@book{CPHandbook,
-  title = {Handbook of Constraint Programming},
-  editor = {F. Rossi and P. {van Beek} and T. Walsh},
-  booktitle = {Handbook of Constraint Programming},
-  publisher = elsevier,
-  year = {2006}
-}
-
 @proceedings{cs05,
   title = {Proceedings of the Seventh International Symposium on Logical Formalizations of Commonsense Reasoning},
   editor = {S. McIlraith and P. Peppas and M. Thielscher},
@@ -1221,21 +1185,6 @@
   booktitle = {Proceedings of the 14th International Symposium on the Design and Diagnostics of Electronic Circuits and Systems (DDECS'11)},
   publisher = ieee,
   year = {2011}
-}
-
-@book{DeclarativeLP,
-  title = {Declarative Logic Programming: Theory, Systems, and Applications},
-  editor = {M. Kifer and Y. Liu},
-  publisher = {{ACM} / Morgan {\&} Claypool},
-  year = {2018}
-}
-
-@book{DLHandbook,
-  title = {The Description Logic Handbook: Theory, Implementation, and Applications},
-  editor = {F. Baader and D. Calvanese and D. McGuinness and D. Nardi and P. Patel-Schneider},
-  booktitle = {The Description Logic Handbook: Theory, Implementation, and Applications},
-  publisher = {Cambridge University Press},
-  year = {2003}
 }
 
 @proceedings{ecai00,
@@ -1389,14 +1338,6 @@
   year = {1995}
 }
 
-@book{EncyclopediaDB,
-  title = {Encyclopedia of Database Systems},
-  editor = {L. Liu and M. {\"O}zsu},
-  booktitle = {Encyclopedia of Database Systems},
-  publisher = springer,
-  year = {2009}
-}
-
 @proceedings{epia01,
   title = {Proceedings of the Tenth Portuguese Conference on Artificial Intelligence (EPIA'01)},
   editor = {P. Brazdil and A. Jorge},
@@ -1513,14 +1454,6 @@
   series = lncs,
   volume = {4932},
   year = {2008}
-}
-
-@book{fpm14,
-  title = {Frequent Pattern Mining},
-  editor = {C. Aggarwal and J. Han},
-  booktitle = {Frequent Pattern Mining},
-  publisher = springer,
-  year = {2014}
 }
 
 @proceedings{fqas09,
@@ -2448,22 +2381,6 @@
   year = {2021}
 }
 
-@book{jm64,
-  title = {Artificial Intelligence and Mathematical Theory of Computation: Papers in Honor of {J}ohn {M}c{C}arthy},
-  editor = {V. Lifschitz},
-  booktitle = {Artificial Intelligence and Mathematical Theory of Computation: Papers in Honor of {J}ohn {M}c{C}arthy},
-  publisher = {Academic Press},
-  year = {1991}
-}
-
-@book{kbc14,
-  title = {Knowledge-Based Configuration: From Research to Business Cases},
-  editor = {A. Felfernig and L. Hotz and C. Bagley and J. Tiihonen},
-  booktitle = {Knowledge-Based Configuration: From Research to Business Cases},
-  publisher = {Elsevier/Morgan Kaufmann},
-  year = {2014}
-}
-
 @proceedings{kdd98,
   title = {Proceedings of the Fourth International Conference on Knowledge Discovery and Data Mining (KDD'98)},
   editor = {R. Agrawal and P. Stolorz and G. Piatetsky-Shapiro},
@@ -2648,28 +2565,11 @@ Reasoning (KR'16)},
   year = {1998}
 }
 
-@book{KRHandbook,
-  title = {Handbook of Knowledge Representation},
-  editor = {V. Lifschitz and F. {van Harmelen} and B. Porter},
-  booktitle = {Handbook of Knowledge Representation},
-  publisher = elsevier,
-  year = {2008}
-}
-
 @proceedings{lash08,
   title = {Proceedings of the Second International Workshop on Logic and Search (LaSh'08)},
   editor = {M. Denecker},
   booktitle = {Proceedings of the Second International Workshop on Logic and Search (LaSh'08)},
   year = {2008}
-}
-
-@book{lbai,
-  title = {Logic-Based Artificial Intelligence},
-  editor = {J. Minker},
-  address = {Dordrecht},
-  booktitle = {Logic-Based Artificial Intelligence},
-  publisher = kluwer,
-  year = {2000}
 }
 
 @proceedings{lics05,
@@ -3034,14 +2934,6 @@ Reasoning (KR'16)},
   year = {2022}
 }
 
-@book{MLHandbook,
-  title = {Handbook of Modal Logic},
-  editor = {P. Blackburn and F. Wolter and J. van Benthem},
-  booktitle = {Handbook of Modal Logic},
-  publisher = elsevier,
-  year = {2006}
-}
-
 @proceedings{modref10,
   title = {Proceedings of the Ninth International Workshop on Constraint Modelling and Reformulation (ModRef'10)},
   booktitle = {Proceedings of the Ninth International Workshop on Constraint Modelling and Reformulation (ModRef'10)},
@@ -3217,14 +3109,6 @@ Reasoning (KR'16)},
   series = {ACM International Conference Proceeding Series},
   volume = {282},
   year = {2008}
-}
-
-@book{PHandbook,
-  title = {Handbook of Philosophical Logic},
-  editor = {D. Gabbay and F. Guenthner},
-  booktitle = {Handbook of Philosophical Logic},
-  publisher = springer,
-  year = {2001}
 }
 
 @proceedings{pkdd07,
@@ -3658,16 +3542,6 @@ Reasoning (KR'16)},
   year = {2012}
 }
 
-@book{SATHandbook,
-  title = {Handbook of Satisfiability},
-  editor = {A. Biere and M. Heule and H. {van Maaren} and T. Walsh},
-  booktitle = {Handbook of Satisfiability},
-  publisher = {IOS Press},
-  series = {Frontiers in Artificial Intelligence and Applications},
-  volume = {185},
-  year = {2009}
-}
-
 @proceedings{sbmf09,
   title = {Proceedings of the Twelfth Brazilian Symposium on Formal Methods (SBMF'09)},
   editor = {M. Oliveira and J. Woodcock},
@@ -3828,14 +3702,6 @@ Reasoning (KR'16)},
   year = {2010}
 }
 
-@book{TableauHandbook,
-  title = {Handbook of Tableau Methods},
-  editor = {M. {D'Agostino} and D. Gabbay and R. H{\"a}hnle and J. Posegga},
-  booktitle = {Handbook of Tableau Methods},
-  publisher = kluwer,
-  year = {1999}
-}
-
 @proceedings{tableaux00,
   title = {Proceedings of the Ninth International Conference on Automated Reasoning with Analytic Tableaux and Related Methods (TABLEAUX'00)},
   editor = {R. Dyckhoff},
@@ -3953,16 +3819,6 @@ Reasoning (KR'16)},
   booktitle = {Proceedings of the fifteenth International Symposium on Temporal Representation and Reasoning (TIME'08)},
   publisher = ieee,
   year = {2008}
-}
-
-@book{TIMEHandbook,
-  title = {Handbook of Temporal Reasoning in Artificial Intelligence},
-  editor = {M. Fisher and D. Gabbay and L. Vila},
-  booktitle = {Handbook of Temporal Reasoning in Artificial Intelligence},
-  publisher = elsevier,
-  series = {Foundations of Artificial Intelligence},
-  volume = {1},
-  year = {2005}
 }
 
 @proceedings{vl65,


### PR DESCRIPTION
I'm currently setting up a system to manage my bibliography files programatically. I'm trying to retain meaningful diffs between the .bib files exported my bibliography management system and krr.bib + procs.bib so I can easily incorporate new changes / contribute new entries. This would of course be easier if we just had a single .bib file, but I can work around that by filtering based on @proceeding entry type. However, the filtering based on @proceeding results in slightly different files, as there are some @book entries sprinkled throughout the procs.bib file.

I propose to move all book entries into krr.bib. Apart from making my life easier, this would also make the separation into krr.bib + procs.bib more consistent, so it's a win-win as far as I'm concearned:) Happy to hear your thoughts!