### PR TITLE
some journal edits

### DIFF
--- a/krr.bib
+++ b/krr.bib
@@ -227,7 +227,7 @@
 @article{aapesc09a,
   title = {Declarative workflows: Balancing between flexibility and support},
   author = {W. van der Aalst and M. Pesic and H. Schonenberg},
-  journal = {Computer Science - R{\&}D},
+  journal = {Computer Science - Research and Development},
   number = {2},
   pages = {99-113},
   volume = {23},
@@ -22749,7 +22749,8 @@
 @article{schsie10a,
   title = {Testing, Diagnosing, Repairing, and Predicting from Regulatory Networks and Datasets},
   author = {T. Schaub and A. Siegel},
-  journal = {ERCIM News, Special Theme: Computational Biology},
+  journal = {{ERCIM} News},
+  note = {Special Theme: Computational Biology},
   pages = {30-31},
   volume = {82},
   year = {2010}


### PR DESCRIPTION
I would suggest not to abbreviate `Computer Science - Research and Development` in line with other journals.

Also, I would suggest removing the Special Theme from `ERCIM News` to keep as in DBLP. The Special Theme can be added in the `note` field.